### PR TITLE
fix: ensure go expressions are highlighted as Go code, not strings

### DIFF
--- a/syntaxes/templ.tmLanguage.json
+++ b/syntaxes/templ.tmLanguage.json
@@ -712,7 +712,7 @@
               "name": "meta.toc-list.id.html"
             }
           },
-          "match": "(?<==)(?:[^\\s<>/'\"]|/(?!>))+",
+          "match": "(?<==)(?:[^\\s{}<>/'\"]|/(?!>))+",
           "name": "string.unquoted.html"
         }
       ]


### PR DESCRIPTION
Fixing go expression highlighted as string for id attribute 

![image](https://github.com/a-h/templ-vscode/assets/58302554/843230f2-38e8-44fc-be51-c33fc20d4c86)
