### PR TITLE
fix: multi-line import expression syntax highlighting

### DIFF
--- a/syntaxes/templ.tmLanguage.json
+++ b/syntaxes/templ.tmLanguage.json
@@ -387,8 +387,8 @@
       ]
     },
     "import-expression": {
-      "begin": "@(.+?{)$",
-      "end": "^\\s*(})$",
+      "begin": "@(.+?{)",
+      "end": "(})",
       "beginCaptures": {
         "0": {
           "patterns": [


### PR DESCRIPTION
## Changes Made
- Updated the `begin` regular expression in `import-expression` by removing the end-of-line anchor (`$`). This allows the expression to match the opening `{` even if it's not on the same line as the `@` symbol.
- Updated the `end` regular expression in `import-expression` by removing the start-of-line anchor (`^`), whitespace matcher (`\\s*`), and the end-of-line anchor (`$`). This modification allows the expression to match the closing `}` regardless of its position on the line.

## Testing
The fix has been tested with various single-line and multi-line import expressions to ensure syntax highlighting doesn't break later in the file. I might not be familiar with all use cases, so I'd recommend checking any expected patterns.
