### PR TITLE
Resolve issue with broken syntax highlighting on switch statements

### DIFF
--- a/syntaxes/templ.tmLanguage.json
+++ b/syntaxes/templ.tmLanguage.json
@@ -350,7 +350,7 @@
     },
     "case-expression": {
       "begin": "^\\s*case .+?:$",
-      "end": "(^\\s*case .+?:$)|(^\\s*default:$)|(^\\s*}$)|(\\s*$)",
+      "end": "(^\\s*case .+?:$)|(^\\s*default:$)|(\\s*$)",
       "captures": {
         "0": {
           "name": "case.switch.html-template.templ",
@@ -369,7 +369,7 @@
     },
     "default-expression": {
       "begin": "^\\s*default:$",
-      "end": "(^\\s*case .+?:$)|(^\\s*default:$)|(^\\s*}$)|(\\s*$)",
+      "end": "(^\\s*case .+?:$)|(^\\s*default:$)|(\\s*$)",
       "captures": {
         "0": {
           "name": "default.switch.html-template.templ",

--- a/syntaxes/templ.tmLanguage.json
+++ b/syntaxes/templ.tmLanguage.json
@@ -350,7 +350,7 @@
     },
     "case-expression": {
       "begin": "^\\s*case .+?:$",
-      "end": "(^\\s*case .+?:$)|(^\\s*default:$)|(^\\s*}$)",
+      "end": "(^\\s*case .+?:$)|(^\\s*default:$)|(^\\s*}$)|(\\s*$)",
       "captures": {
         "0": {
           "name": "case.switch.html-template.templ",
@@ -369,7 +369,7 @@
     },
     "default-expression": {
       "begin": "^\\s*default:$",
-      "end": "(^\\s*case .+?:$)|(^\\s*default:$)|(^\\s*}$)",
+      "end": "(^\\s*case .+?:$)|(^\\s*default:$)|(^\\s*}$)|(\\s*$)",
       "captures": {
         "0": {
           "name": "default.switch.html-template.templ",


### PR DESCRIPTION
# Overview
I noticed while using the templ-vscode extension that switch statements within templ functions were not properly closing. This causes the actual closing curly brace to appear as invalid and all code below the broken switch highlight loses highlighting all together. 

After some digging, I think I found the problem is with the `case-expression` and `default-expression` syntax rules not having a proper "end" regex when they are the last statement within the switch. Currently, it relies on a closing curly brace for the last statement, but I think that curly brace is actually being taken by the outer switch's syntax and not available as a token to close the `case`/`default` expressions. 

To resolve this, I replaced the closing curly brace regex with a regex that looks for whitespace at the end of the available block and treats that as an "end". 

Closes: https://github.com/a-h/templ/issues/437

### Before
![Screenshot 2024-01-18 at 2 14 42 PM](https://github.com/templ-go/templ-vscode/assets/42357034/60100a98-25a6-4ec7-9546-2392dd8de8bb)

### After
![Screenshot 2024-01-18 at 2 15 09 PM](https://github.com/templ-go/templ-vscode/assets/42357034/8f24a46d-f21b-4928-a7bd-e1a99a31e657)

