### PR TITLE
Resolve single line import expression syntax highlighting #508

### DIFF
--- a/syntaxes/templ.tmLanguage.json
+++ b/syntaxes/templ.tmLanguage.json
@@ -179,6 +179,9 @@
           "include": "#call-expression"
         },
         {
+          "include": "#empty-import-expression"
+        },
+        {
           "include": "#import-expression"
         },
         {
@@ -386,6 +389,18 @@
         }
       ]
     },
+    "empty-import-expression":{
+      "match": "@(?:[A-z_][A-z_0-9]*\\.)?[A-z_][A-z_0-9]*\\(.*\\)\\s*$",
+      "captures": {
+        "0": {
+          "patterns": [
+            {
+              "include": "#import-expression-start"
+            }
+          ]
+        }
+      }
+    },
     "import-expression": {
       "begin": "@(?:[A-z_][A-z_0-9]*\\.)?[A-z_][A-z_0-9]*\\(.*\\)\\s*{$",
       "beginCaptures": {
@@ -413,6 +428,9 @@
     "import-expression-start": {
       "begin": "(@)",
       "beginCaptures": {
+        "0": {
+          "name": "start.import-expression.templ"
+        },
         "1": {
           "name": "keyword.control.go"
         }
@@ -427,12 +445,7 @@
         {
           "include": "source.go"
         }
-      ],
-      "captures": {
-        "0": {
-          "name": "start.import-expression.templ"
-        }
-      }
+      ]
     },
     "call-expression": {
       "begin": "({\\!)\\s+",

--- a/syntaxes/templ.tmLanguage.json
+++ b/syntaxes/templ.tmLanguage.json
@@ -428,9 +428,6 @@
     "import-expression-start": {
       "begin": "(@)",
       "beginCaptures": {
-        "0": {
-          "name": "start.import-expression.templ"
-        },
         "1": {
           "name": "keyword.control.go"
         }
@@ -445,7 +442,12 @@
         {
           "include": "source.go"
         }
-      ]
+      ],
+      "captures": {
+        "0": {
+          "name": "start.import-expression.templ"
+        }
+      }
     },
     "call-expression": {
       "begin": "({\\!)\\s+",

--- a/syntaxes/templ.tmLanguage.json
+++ b/syntaxes/templ.tmLanguage.json
@@ -387,8 +387,7 @@
       ]
     },
     "import-expression": {
-      "begin": "@(.+?{)",
-      "end": "(})",
+      "begin": "@(?:[A-z_][A-z_0-9]*\\.)?[A-z_][A-z_0-9]*\\(.*\\)\\s*{$",
       "beginCaptures": {
         "0": {
           "patterns": [
@@ -398,6 +397,7 @@
           ]
         }
       },
+      "end": "(})",
       "endCaptures": {
         "1": {
           "name": "punctuation.brace.close"


### PR DESCRIPTION
# Overview
Partially resolves https://github.com/a-h/templ/issues/508.

I found that the previous `begin` regex for `import-expression` would close when it hit the first open curly brace. I updated this regex to instead pattern match `@`, a function name, open/close parenthesis, then the opening curly brace. This resolved the issue for inline cases. 

Additionally, I added an `empty-import-expression` that only matches against all but the opening curly brace for inline components that are not provided children. 

### Before
![before](https://github.com/templ-go/templ-vscode/assets/42357034/d0c8f31c-9f30-44ed-8ca6-18676b051a68)

### After
![after](https://github.com/templ-go/templ-vscode/assets/42357034/5fc8c9a8-8968-4118-9e6f-e41730832b95)

However, this does not entirely resolve https://github.com/a-h/templ/issues/508 which specifically asked about multi-line parameters. After reading up on TextMate (which is what VSCode uses under the hood) and finding this [issue](https://github.com/microsoft/vscode-textmate/issues/41), it seems that multi-line pattern matching is not natively supported. It does seem possible to nest pattern matching to properly resolve the multi-line params, but I figured this fix was enough for one PR. 

I'll likely spend some more time exploring TextMate and see if I can resolve the multi-line param syntax highlighting and can push another PR later.