### PR TITLE
Refactor import-expression syntax regex matching

### DIFF
--- a/syntaxes/templ.tmLanguage.json
+++ b/syntaxes/templ.tmLanguage.json
@@ -389,7 +389,7 @@
     "import-expression": {
       "patterns": [
         {
-          "name": "start.import-expression.templ",
+          "name": "import-expression.templ",
           "begin": "(@)((?:[A-z_][A-z_0-9]*\\.)?[A-z_][A-z_0-9]*\\()",
           "beginCaptures": {
             "1": {
@@ -403,35 +403,42 @@
               ]
             }
           },
-          "end": "(\\))",
-          "endCaptures": {
-            "1": {
-              "name": "punctuation.definition.end.bracket.round.go"
-            }
-          },
+          "end": "\\s*$",
           "patterns": [
             {
-              "include": "source.go"
-            }
-          ]
-        },
-        {
-          "name": "children.import-expression.templ",
-          "begin": "(?<=\\))\\s({)$",
-          "beginCaptures": {
-            "1": {
-              "name": "punctuation.brace.open"
-            }
-          },
-          "end": "^\\s*(})$",
-          "endCaptures": {
-            "1": {
-              "name": "punctuation.brace.close"
-            }
-          },
-          "patterns": [
+              "name": "params.import-expression.templ",
+              "begin": "(?<=\\()",
+              "end": "(\\))",
+              "endCaptures": {
+                "1": {
+                  "name": "punctuation.definition.end.bracket.round.go"
+                }
+              },
+              "patterns": [
+                {
+                  "include": "source.go"
+                }
+              ]
+            },
             {
-              "include": "#template-node"
+              "name": "children.import-expression.templ",
+              "begin": "(?<=\\))\\s({)$",
+              "beginCaptures": {
+                "1": {
+                  "name": "punctuation.brace.open"
+                }
+              },
+              "end": "^\\s*(})$",
+              "endCaptures": {
+                "1": {
+                  "name": "punctuation.brace.close"
+                }
+              },
+              "patterns": [
+                {
+                  "include": "#template-node"
+                }
+              ]
             }
           ]
         }

--- a/syntaxes/templ.tmLanguage.json
+++ b/syntaxes/templ.tmLanguage.json
@@ -390,12 +390,15 @@
       "patterns": [
         {
           "name": "start.import-expression.templ",
-          "begin": "@(?:[A-z_][A-z_0-9]*\\.)?[A-z_][A-z_0-9]*\\(",
+          "begin": "(@)((?:[A-z_][A-z_0-9]*\\.)?[A-z_][A-z_0-9]*\\()",
           "beginCaptures": {
-            "0": {
+            "1": {
+              "name": "keyword.control.go"
+            },
+            "2": {
               "patterns": [
                 {
-                  "include": "#import-expression-start"
+                  "include": "source.go"
                 }
               ]
             }
@@ -431,20 +434,6 @@
               "include": "#template-node"
             }
           ]
-        }
-      ]
-    },
-    "import-expression-start": {
-      "begin": "(@)",
-      "beginCaptures": {
-        "1": {
-          "name": "keyword.control.go"
-        }
-      },
-      "end": "\\s*$",
-      "patterns": [
-        {
-          "include": "source.go"
         }
       ]
     },

--- a/syntaxes/templ.tmLanguage.json
+++ b/syntaxes/templ.tmLanguage.json
@@ -403,7 +403,7 @@
               ]
             }
           },
-          "end": "\\s*$",
+          "end": "(?<=\\))$|(?<=})$",
           "patterns": [
             {
               "name": "params.import-expression.templ",

--- a/syntaxes/templ.tmLanguage.json
+++ b/syntaxes/templ.tmLanguage.json
@@ -179,9 +179,6 @@
           "include": "#call-expression"
         },
         {
-          "include": "#empty-import-expression"
-        },
-        {
           "include": "#import-expression"
         },
         {
@@ -389,41 +386,53 @@
         }
       ]
     },
-    "empty-import-expression":{
-      "match": "@(?:[A-z_][A-z_0-9]*\\.)?[A-z_][A-z_0-9]*\\(.*\\)\\s*$",
-      "captures": {
-        "0": {
-          "patterns": [
-            {
-              "include": "#import-expression-start"
-            }
-          ]
-        }
-      }
-    },
     "import-expression": {
-      "begin": "@(?:[A-z_][A-z_0-9]*\\.)?[A-z_][A-z_0-9]*\\(.*\\)\\s*{$",
-      "beginCaptures": {
-        "0": {
-          "patterns": [
-            {
-              "include": "#import-expression-start"
-            }
-          ]
-        }
-      },
-      "end": "(})",
-      "endCaptures": {
-        "1": {
-          "name": "punctuation.brace.close"
-        }
-      },
       "patterns": [
         {
-          "include": "#template-node"
+          "name": "start.import-expression.templ",
+          "begin": "@(?:[A-z_][A-z_0-9]*\\.)?[A-z_][A-z_0-9]*\\(",
+          "beginCaptures": {
+            "0": {
+              "patterns": [
+                {
+                  "include": "#import-expression-start"
+                }
+              ]
+            }
+          },
+          "end": "(\\))",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.definition.end.bracket.round.go"
+            }
+          },
+          "patterns": [
+            {
+              "include": "source.go"
+            }
+          ]
+        },
+        {
+          "name": "children.import-expression.templ",
+          "begin": "(?<=\\))\\s({)$",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.brace.open"
+            }
+          },
+          "end": "^\\s*(})$",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.brace.close"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#template-node"
+            }
+          ]
         }
-      ],
-      "name": "import-expression.templ"
+      ]
     },
     "import-expression-start": {
       "begin": "(@)",
@@ -432,22 +441,12 @@
           "name": "keyword.control.go"
         }
       },
-      "end": "({)$",
-      "endCaptures": {
-        "1": {
-          "name": "punctuation.brace.open"
-        }
-      },
+      "end": "\\s*$",
       "patterns": [
         {
           "include": "source.go"
         }
-      ],
-      "captures": {
-        "0": {
-          "name": "start.import-expression.templ"
-        }
-      }
+      ]
     },
     "call-expression": {
       "begin": "({\\!)\\s+",


### PR DESCRIPTION
# Overview
Relates to https://github.com/a-h/templ/issues/524

Previously, I fixed inline import expressions in https://github.com/templ-go/templ-vscode/pull/29 by breaking out empty (no children) expressions into their own rule and fixing both styles individually. After taking a deep-dive into the TextMate grammar engine that VSCode uses, I put together a much better approach that resolves inline/multi-line params and children/no-children import expressions all as one rule. 

### Before
<img width="358" alt="Screenshot 2024-02-14 at 10 50 57 AM" src="https://github.com/templ-go/templ-vscode/assets/42357034/ec2b598e-4485-4bec-accd-f269ddc9e7d7">

### After
<img width="359" alt="Screenshot 2024-02-14 at 10 50 05 AM" src="https://github.com/templ-go/templ-vscode/assets/42357034/6f2cb981-bc90-432c-9528-01a4a655297e">
