### PR TITLE
Refactor if/else-if statement syntax regex matching

### DIFF
--- a/syntaxes/templ.tmLanguage.json
+++ b/syntaxes/templ.tmLanguage.json
@@ -308,24 +308,46 @@
       "name": "else.html-template.templ"
     },
     "else-if-expression": {
-      "begin": "\\s+else\\s+if .+?{\\s*$",
-      "end": "(^\\s*}$)|(^\\s*}(?=\\s*else\\s*{$))|(^\\s*}(?=\\s*else\\s*if .+?{\\s*$))",
-      "captures": {
-        "0": {
-          "name": "meta.embedded.block.go",
+      "name": "else-if.html-template.templ",
+      "begin": "\\s(else if)\\s",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.go"
+        }
+      },
+      "end": "(?<=\\s*})",
+      "patterns": [
+        {
+          "name": "expression.else-if.html-template.templ",
+          "begin": "(?<=if\\s)",
+          "end": "({)$",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.definition.begin.bracket.curly.go"
+            }
+          },
           "patterns": [
             {
               "include": "source.go"
             }
           ]
-        }
-      },
-      "patterns": [
+        },
         {
-          "include": "#template-node"
+          "name": "block.else-if.html-template.templ",
+          "begin": "(?<={)$",
+          "end": "^\\s*(})",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.definition.end.bracket.curly.go"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#template-node"
+            }
+          ]
         }
-      ],
-      "name": "else.if.html-template.templ"
+      ]
     },
     "for-expression": {
       "begin": "^\\s*for .+{",

--- a/syntaxes/templ.tmLanguage.json
+++ b/syntaxes/templ.tmLanguage.json
@@ -246,24 +246,46 @@
       "name": "expression.html-template.templ"
     },
     "if-expression": {
-      "begin": "^\\s*if .+?{\\s*$",
-      "end": "(^\\s*}$)|(^\\s*}(?=\\s*else\\s*{$))|(^\\s*}(?=\\s*else\\s*if .+?{\\s*$))",
-      "captures": {
-        "0": {
-          "name": "meta.embedded.block.go",
+      "name": "if.html-template.templ",
+      "begin": "^\\s*(if)\\s",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.go"
+        }
+      },
+      "end": "(?<=\\s*})",
+      "patterns": [
+        {
+          "name": "expression.if.html-template.templ",
+          "begin": "(?<=if\\s)",
+          "end": "({)$",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.definition.begin.bracket.curly.go"
+            }
+          },
           "patterns": [
             {
               "include": "source.go"
             }
           ]
-        }
-      },
-      "patterns": [
+        },
         {
-          "include": "#template-node"
+          "name": "block.if.html-template.templ",
+          "begin": "(?<={)$",
+          "end": "^\\s*(})",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.definition.end.bracket.curly.go"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#template-node"
+            }
+          ]
         }
-      ],
-      "name": "if.html-template.templ"
+      ]
     },
     "else-expression": {
       "begin": "\\s+else\\s+{\\s*$",
@@ -389,7 +411,7 @@
         }
       ]
     },
-    "empty-import-expression":{
+    "empty-import-expression": {
       "match": "@(?:[A-z_][A-z_0-9]*\\.)?[A-z_][A-z_0-9]*\\(.*\\)\\s*$",
       "captures": {
         "0": {


### PR DESCRIPTION
# Overview

Relates to https://github.com/a-h/templ/issues/524

This resolves the broken syntax highlight on if/else-if multi-line condition statements.

### Before
![before-broken-statements](https://github.com/templ-go/templ-vscode/assets/42357034/cb444caa-6b3f-417e-958a-f7dc7431b126)

### After
![after-working-statements](https://github.com/templ-go/templ-vscode/assets/42357034/8aa1888e-1181-4d57-b314-371f5b032047)
