### PR TITLE
Add syntax highlighting for style/script tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
         "embeddedLanguages": {
           "meta.embedded.block.go": "go",
           "meta.embedded.block.js": "js",
-          "meta.embedded.block.html": "html"
+          "meta.embedded.block.html": "html",
+          "meta.embedded.block.css": "css"
         }
       }
     ],

--- a/syntaxes/templ.tmLanguage.json
+++ b/syntaxes/templ.tmLanguage.json
@@ -222,6 +222,9 @@
         },
         {
           "include": "#switch-expression"
+        },
+        {
+          "include": "#script-element"
         }
       ]
     },
@@ -389,7 +392,7 @@
         }
       ]
     },
-    "empty-import-expression":{
+    "empty-import-expression": {
       "match": "@(?:[A-z_][A-z_0-9]*\\.)?[A-z_][A-z_0-9]*\\(.*\\)\\s*$",
       "captures": {
         "0": {
@@ -650,6 +653,25 @@
       "patterns": [
         {
           "include": "#tag-stuff"
+        }
+      ]
+    },
+    "script-element": {
+      "name": "meta.tag.script.html",
+      "begin": "(?<=<script.*>)",
+      "end": "</script>",
+      "endCaptures": {
+        "0": {
+          "patterns": [
+            {
+              "include": "#close-element"
+            }
+          ]
+        }
+      },
+      "patterns": [
+        {
+          "include": "source.js"
         }
       ]
     },

--- a/syntaxes/templ.tmLanguage.json
+++ b/syntaxes/templ.tmLanguage.json
@@ -225,6 +225,9 @@
         },
         {
           "include": "#script-element"
+        },
+        {
+          "include": "#style-element"
         }
       ]
     },
@@ -672,6 +675,25 @@
       "patterns": [
         {
           "include": "source.js"
+        }
+      ]
+    },
+    "style-element": {
+      "name": "meta.tag.style.html",
+      "begin": "(?<=<style.*>)",
+      "end": "</style>",
+      "endCaptures": {
+        "0": {
+          "patterns": [
+            {
+              "include": "#close-element"
+            }
+          ]
+        }
+      },
+      "patterns": [
+        {
+          "include": "source.css"
         }
       ]
     },


### PR DESCRIPTION
# Overview
Resolves https://github.com/a-h/templ/issues/489

Through investigation, it appeared that there was no syntax highlighting present at all for `<script>` and `<style>` tags, leading the what syntax highlighting was present to come from Go or other sources. 

The additions made here capture  `<script>` and `<style>` explicitly  and mark the inner contents with the JS and CSS sources respectively.

### Before (from  https://github.com/a-h/templ/issues/489)
![before-script-style](https://private-user-images.githubusercontent.com/14093866/301936011-30bee435-985e-413b-b1f6-d4cb2ba9ccd3.PNG?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MDgxOTg1MDEsIm5iZiI6MTcwODE5ODIwMSwicGF0aCI6Ii8xNDA5Mzg2Ni8zMDE5MzYwMTEtMzBiZWU0MzUtOTg1ZS00MTNiLWIxZjYtZDRjYjJiYTljY2QzLlBORz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDAyMTclMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQwMjE3VDE5MzAwMVomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTE0Nzk5NGM4NzcxOTgwMTllYjk2MDhiNjJkNzk5YzZjMDRiNDRhNDk3MDI5MTVlZTU0NjgwYTljMzRiNTE1MDYmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JmFjdG9yX2lkPTAma2V5X2lkPTAmcmVwb19pZD0wIn0.-h-ibHgDnRaJh-wmpuB8PitBsmKr6pFwg6tK_9foYvw) 

### After
![style-script-fix](https://github.com/templ-go/templ-vscode/assets/42357034/f62c05c1-4509-4f31-975b-2dddecef85d0)

