### PR TITLE
Add syntax highlighting support for HTML attribute conditional statements

### DIFF
--- a/syntaxes/templ.tmLanguage.json
+++ b/syntaxes/templ.tmLanguage.json
@@ -389,7 +389,7 @@
         }
       ]
     },
-    "empty-import-expression":{
+    "empty-import-expression": {
       "match": "@(?:[A-z_][A-z_0-9]*\\.)?[A-z_][A-z_0-9]*\\(.*\\)\\s*$",
       "captures": {
         "0": {
@@ -763,6 +763,48 @@
         }
       ]
     },
+    "tag-if-attribute": {
+      "name": "if.attribute.html",
+      "begin": "^\\s*(if)\\s",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.go"
+        }
+      },
+      "end": "(?<=\\s*})",
+      "patterns": [
+        {
+          "name": "expression.if.attribute.html",
+          "begin": "(?<=if\\s)",
+          "end": "({)$",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.brace.open"
+            }
+          },
+          "patterns": [
+            {
+              "include": "source.go"
+            }
+          ]
+        },
+        {
+          "name": "block.if.attribute.html",
+          "begin": "(?<={)$",
+          "end": "^\\s*(})",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.brace.close"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#tag-stuff"
+            }
+          ]
+        }
+      ]
+    },
     "tag-stuff": {
       "patterns": [
         {
@@ -776,6 +818,9 @@
         },
         {
           "include": "#string-expression"
+        },
+        {
+          "include": "#tag-if-attribute"
         }
       ]
     }

--- a/syntaxes/templ.tmLanguage.json
+++ b/syntaxes/templ.tmLanguage.json
@@ -847,6 +847,29 @@
         }
       ]
     },
+    "tag-else-attribute": {
+      "name": "else.attribute.html",
+      "begin": "\\s(else)\\s({)$",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.go"
+        },
+        "2": {
+          "name": "punctuation.brace.open"
+        }
+      },
+      "end": "^\\s*(})$",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.brace.close"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#tag-stuff"
+        }
+      ]
+    },
     "tag-stuff": {
       "patterns": [
         {
@@ -866,6 +889,9 @@
         },
         {
           "include": "#tag-else-if-attribute"
+        },
+        {
+          "include": "#tag-else-attribute"
         }
       ]
     }

--- a/syntaxes/templ.tmLanguage.json
+++ b/syntaxes/templ.tmLanguage.json
@@ -805,6 +805,48 @@
         }
       ]
     },
+    "tag-else-if-attribute": {
+      "name": "else-if.attribute.html",
+      "begin": "\\s(else if)\\s",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.go"
+        }
+      },
+      "end": "(?<=\\s*})",
+      "patterns": [
+        {
+          "name": "expression.else-if.attribute.html",
+          "begin": "(?<=if\\s)",
+          "end": "({)$",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.brace.open"
+            }
+          },
+          "patterns": [
+            {
+              "include": "source.go"
+            }
+          ]
+        },
+        {
+          "name": "block.else-if.attribute.html",
+          "begin": "(?<={)$",
+          "end": "^\\s*(})",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.brace.close"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#tag-stuff"
+            }
+          ]
+        }
+      ]
+    },
     "tag-stuff": {
       "patterns": [
         {
@@ -821,6 +863,9 @@
         },
         {
           "include": "#tag-if-attribute"
+        },
+        {
+          "include": "#tag-else-if-attribute"
         }
       ]
     }


### PR DESCRIPTION
# Overview
Resolves https://github.com/a-h/templ/issues/533

Added support for syntax highlighting on HTML attribute if/else expressions. I also went ahead and added support for else-if expressions, but based on the formatting that the LSP was making, it seems that this is not currently supported. But if you guys ever decide to add support for it you'll have the syntax highlighting ready to go!

I also put the pattern matching together in such a way that it supports multi-line if/else-if condition statements as well as nested logic (as shown in the after screenshot below).

### Before
![htm-attr-conditionals-broken](https://github.com/templ-go/templ-vscode/assets/42357034/b3ec30bb-91ab-43e0-a522-9c36a9d240e4)

### After
![htm-attr-conditionals-fixed](https://github.com/templ-go/templ-vscode/assets/42357034/1591a422-ce42-441d-9409-eee691306ae0)
