### PR TITLE
fix: Syntax issue when closing a script on the same line

### DIFF
--- a/syntaxes/templ.tmLanguage.json
+++ b/syntaxes/templ.tmLanguage.json
@@ -712,7 +712,7 @@
     },
     "script-element": {
       "name": "meta.tag.script.html",
-      "begin": "(?<=<script.*>)",
+      "begin": "(?<=<script.*>)(?<!</script>)",
       "end": "</script>",
       "endCaptures": {
         "0": {


### PR DESCRIPTION
This PR fixes a syntax highlight issue when closing a script tag on the same line.
The issue is caused because of the `.*>` which matches twice, first were we would expect, after `<script>` and then again after `<script></script>` because all `></script` is captured by `.*`
My change seems to fix it without introducing regressions.

![Screenshot 2024-02-24 at 11 05 26](https://github.com/templ-go/templ-vscode/assets/2331645/253b3d72-c7aa-4798-b1f6-01f19fd90dd1)
![Screenshot 2024-02-24 at 11 05 52](https://github.com/templ-go/templ-vscode/assets/2331645/9444785f-5911-405e-b025-a4f8ccbcdea5)


Before:
![Screenshot 2024-02-24 at 12 13 28](https://github.com/templ-go/templ-vscode/assets/2331645/714e238b-675d-4bbe-8a45-a74f68b23292)
After:
![Screenshot 2024-02-24 at 12 12 42](https://github.com/templ-go/templ-vscode/assets/2331645/c154b207-c5eb-4937-902f-b2a313ac9f67)

