### PR TITLE
Add syntax highlighting for struct method import expression, fixes #566

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ All notable changes to this project will be documented in this file. See [standa
 
 * Add restart command
 
+### [0.0.20](https://github.com/templ-go/templ-vscode/compare/v0.0.19...v0.0.20) (2024-02-18)
+
+* Resolve single line import expression syntax highlighting, fixes [#508](https://github.com/a-h/templ/issues/508) in #29
+* Refactor import-expression syntax regex matching, fixes [#524](https://github.com/a-h/templ/issues/524) in #30
+* Refactor if/else-if statement syntax regex matching, fixes [#524](https://github.com/a-h/templ/issues/524) in #31
+* Add syntax highlighting for style/script tags, fixes [#489](https://github.com/a-h/templ/issues/489) in #32
+* Add syntax highlighting support for HTML attribute conditional statements, fixes [#533](https://github.com/a-h/templ/issues/533) in #33
+
 ### [0.0.19](https://github.com/a-h/templ-vscode/compare/v0.0.18...v0.0.19) (2024-01-19)
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### Unreleased
+
+* Add syntax highlighting for struct method import expression, fixes [#566](https://github.com/a-h/templ/issues/566) in #38
+
 ### [0.0.21](https://github.com/a-h/templ-vscode/compare/v0.0.20...v0.0.21) (2024-02-27)
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-### Unreleased
-
-* Add syntax highlighting for struct method import expression, fixes [#566](https://github.com/a-h/templ/issues/566) in #38
-
 ### [0.0.21](https://github.com/a-h/templ-vscode/compare/v0.0.20...v0.0.21) (2024-02-27)
 
 ### Features

--- a/syntaxes/templ.tmLanguage.json
+++ b/syntaxes/templ.tmLanguage.json
@@ -436,18 +436,6 @@
         }
       ]
     },
-    "empty-import-expression": {
-      "match": "@(?:[A-z_][A-z_0-9]*\\.)?[A-z_][A-z_0-9]*\\(.*\\)\\s*$",
-      "captures": {
-        "0": {
-          "patterns": [
-            {
-              "include": "#import-expression-start"
-            }
-          ]
-        }
-      }
-    },
     "import-expression": {
       "patterns": [
         {

--- a/syntaxes/templ.tmLanguage.json
+++ b/syntaxes/templ.tmLanguage.json
@@ -440,7 +440,7 @@
       "patterns": [
         {
           "name": "import-expression.templ",
-          "begin": "(@)((?:[A-z_][A-z_0-9]*\\.)?[A-z_][A-z_0-9]*\\()",
+          "begin": "(@)((?:[A-z_][A-z_0-9]*\\.)?[A-z_][A-z_0-9]*(?:\\(|{))",
           "beginCaptures": {
             "1": {
               "name": "keyword.control.go"
@@ -455,6 +455,28 @@
           },
           "end": "(?<=\\))$|(?<=})$",
           "patterns": [
+            {
+              "name": "struct-method.import-expression.templ",
+              "begin": "(?<=[A-z_0-9]{)",
+              "end": "\\s*(})(\\.[A-z_][A-z_0-9]*\\()",
+              "endCaptures": {
+                "1": {
+                  "name": "punctuation.definition.end.bracket.curly.go"
+                },
+                "2": {
+                  "patterns": [
+                    {
+                      "include": "source.go"
+                    }
+                  ]
+                }
+              },
+              "patterns": [
+                {
+                  "include": "source.go"
+                }
+              ]
+            },
             {
               "name": "params.import-expression.templ",
               "begin": "(?<=\\()",


### PR DESCRIPTION
# Overview
Resolves https://github.com/a-h/templ/issues/566

Added syntax highlighting for struct methods being added to the next release of `templ`. 

### Before
![struct-method-broken](https://github.com/templ-go/templ-vscode/assets/42357034/3033f33f-f668-4bce-a40e-468eee437087)

### After
![struct-method-fixed](https://github.com/templ-go/templ-vscode/assets/42357034/b64135b3-7ba2-4ebb-918e-8f7d4e9eb4cf)
