### PR TITLE
fix: non-function import expression syntax highlighting

### DIFF
--- a/syntaxes/templ.tmLanguage.json
+++ b/syntaxes/templ.tmLanguage.json
@@ -440,7 +440,7 @@
       "patterns": [
         {
           "name": "import-expression.templ",
-          "begin": "(@)((?:[A-z_][A-z_0-9]*\\.)?[A-z_][A-z_0-9]*(?:\\(|{))",
+          "begin": "(@)((?:[A-z_][A-z_0-9]*\\.)?[A-z_][A-z_0-9]*(?:\\(|{|$))",
           "beginCaptures": {
             "1": {
               "name": "keyword.control.go"
@@ -453,7 +453,7 @@
               ]
             }
           },
-          "end": "(?<=\\))$|(?<=})$",
+          "end": "(?<=\\))$|(?<=})$|(?<=$)",
           "patterns": [
             {
               "name": "struct-method.import-expression.templ",


### PR DESCRIPTION
# Overview
This is a follow-up to #38 from a [recommendation](https://github.com/a-h/templ/issues/566#issuecomment-1969081118) in https://github.com/a-h/templ/issues/566. This adds support for syntax highlighting on non-function components such as the following:

```templ
templ higherOrderTemplate(a, b templ.Component) {
	<div class="left">
		@a
	</div>
	<div class="right">
		@b
	</div>
}
```

### Before
<img width="367" alt="Screenshot 2024-02-28 at 2 08 19 PM" src="https://github.com/templ-go/templ-vscode/assets/42357034/d18a4d8a-9908-47f7-b5b8-11a9b1927ea4">

### After
<img width="369" alt="Screenshot 2024-02-28 at 2 07 18 PM" src="https://github.com/templ-go/templ-vscode/assets/42357034/51682260-75db-4c50-9282-f00693086763">

## Caveat
However, since this is reusing the current import-expression pattern it passes the function name into `source.go` which marks the syntax as a variable instead of a function since it doesn't have an open parenthesis. Just wanted to point this out to make sure this is okay or if we'd like to override this scenario to force the function syntax token?

<img width="485" alt="Screenshot 2024-02-28 at 2 07 05 PM" src="https://github.com/templ-go/templ-vscode/assets/42357034/181e4e0a-b00c-4e2c-ab39-3c897db2f912">
