### PR TITLE
Fix: Closing style tags on the same line cause syntax highlight issues

### DIFF
--- a/syntaxes/templ.tmLanguage.json
+++ b/syntaxes/templ.tmLanguage.json
@@ -741,7 +741,7 @@
     },
     "style-element": {
       "name": "meta.tag.style.html",
-      "begin": "(?<=<style.*>)",
+      "begin": "(?<=<style.*>)(?<!</style>)",
       "end": "</style>",
       "endCaptures": {
         "0": {


### PR DESCRIPTION
Is the same fix as #35 but for style tags now, as requested by @alehechka.

This PR fixes a syntax highlight issue when closing a style tag on the same line.
The issue is caused because of the .*> which matches twice, first were we would expect, after `<style>` and then again after `<style>...</style>` because all `>...</style` is captured by .*
My change seems to fix it without introducing regressions.

Examples of the issue (note the closing of the tags`>` )
![Screenshot 2024-02-29 at 15 24 30](https://github.com/templ-go/templ-vscode/assets/2331645/1de06806-974c-45ad-9a54-0cb960c066d6)
![Screenshot 2024-02-29 at 15 24 06](https://github.com/templ-go/templ-vscode/assets/2331645/90dbe28f-63ce-4e7c-aacd-27a22ef3357b)

This is how it can mess-up your file if you have more code, even after the closing of the template.
![Screenshot 2024-02-29 at 15 23 44](https://github.com/templ-go/templ-vscode/assets/2331645/39e053af-2e4a-4091-be4a-005eb97fddb5)

This is how it looks after the fix
![Screenshot 2024-02-29 at 15 23 24](https://github.com/templ-go/templ-vscode/assets/2331645/bf75cdb2-921a-4634-81be-c3d071858987)


