### PR TITLE
fix(#652): remove usage of lookbehind regex with wildcard lengths 

### DIFF
--- a/syntaxes/templ.tmLanguage.json
+++ b/syntaxes/templ.tmLanguage.json
@@ -350,7 +350,7 @@
           "name": "keyword.control.go"
         },
         "2": {
-          "name": "punctuation.definition.end.bracket.curly.go"
+          "name": "punctuation.definition.begin.bracket.curly.go"
         }
       },
       "end": "^\\s*(})$",

--- a/syntaxes/templ.tmLanguage.json
+++ b/syntaxes/templ.tmLanguage.json
@@ -309,7 +309,7 @@
           "name": "keyword.control.go"
         }
       },
-      "end": "(?<=\\s*})",
+      "end": "(?<=})",
       "patterns": [
         {
           "name": "expression.if.html-template.templ",
@@ -344,16 +344,19 @@
       ]
     },
     "else-expression": {
-      "begin": "\\s+else\\s+{\\s*$",
-      "end": "^\\s*}$",
-      "captures": {
-        "0": {
-          "name": "meta.embedded.block.go",
-          "patterns": [
-            {
-              "include": "source.go"
-            }
-          ]
+      "begin": "\\s+(else)\\s+({)\\s*$",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.go"
+        },
+        "2": {
+          "name": "punctuation.definition.end.bracket.curly.go"
+        }
+      },
+      "end": "^\\s*(})$",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.definition.end.bracket.curly.go"
         }
       },
       "patterns": [
@@ -371,7 +374,7 @@
           "name": "keyword.control.go"
         }
       },
-      "end": "(?<=\\s*})",
+      "end": "(?<=})",
       "patterns": [
         {
           "name": "expression.else-if.html-template.templ",
@@ -929,7 +932,7 @@
           "name": "keyword.control.go"
         }
       },
-      "end": "(?<=\\s*})",
+      "end": "(?<=})",
       "patterns": [
         {
           "name": "expression.if.attribute.html",
@@ -971,7 +974,7 @@
           "name": "keyword.control.go"
         }
       },
-      "end": "(?<=\\s*})",
+      "end": "(?<=})",
       "patterns": [
         {
           "name": "expression.else-if.attribute.html",

--- a/syntaxes/templ.tmLanguage.json
+++ b/syntaxes/templ.tmLanguage.json
@@ -235,6 +235,12 @@
           "include": "#import-expression"
         },
         {
+          "include": "#script-element"
+        },
+        {
+          "include": "#style-element"
+        },
+        {
           "include": "#element"
         },
         {
@@ -272,12 +278,6 @@
         },
         {
           "include": "#switch-expression"
-        },
-        {
-          "include": "#script-element"
-        },
-        {
-          "include": "#style-element"
         }
       ]
     },
@@ -778,7 +778,25 @@
     },
     "script-element": {
       "name": "meta.tag.script.html",
-      "begin": "(?<=<script.*>)(?<!</script>)",
+      "begin": "(<)(script)([^>]*)(>)",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.definition.tag.html"
+        },
+        "2": {
+          "name": "entity.name.tag.html"
+        },
+        "3": {
+          "patterns": [
+            {
+              "include": "#tag-stuff"
+            }
+          ]
+        },
+        "4": {
+          "name": "punctuation.definition.tag.html"
+        }
+      },
       "end": "</script>",
       "endCaptures": {
         "0": {
@@ -797,7 +815,25 @@
     },
     "style-element": {
       "name": "meta.tag.style.html",
-      "begin": "(?<=<style.*>)(?<!</style>)",
+      "begin": "(<)(style)([^>]*)(>)",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.definition.tag.html"
+        },
+        "2": {
+          "name": "entity.name.tag.html"
+        },
+        "3": {
+          "patterns": [
+            {
+              "include": "#tag-stuff"
+            }
+          ]
+        },
+        "4": {
+          "name": "punctuation.definition.tag.html"
+        }
+      },
       "end": "</style>",
       "endCaptures": {
         "0": {

--- a/tests/snap/basic_features.templ.snap
+++ b/tests/snap/basic_features.templ.snap
@@ -217,7 +217,7 @@
 #   ^ source.templ html-template.templ block.html-template.templ else.html-template.templ
 #    ^^^^ source.templ html-template.templ block.html-template.templ else.html-template.templ keyword.control.go
 #        ^ source.templ html-template.templ block.html-template.templ else.html-template.templ
-#         ^ source.templ html-template.templ block.html-template.templ else.html-template.templ punctuation.definition.end.bracket.curly.go
+#         ^ source.templ html-template.templ block.html-template.templ else.html-template.templ punctuation.definition.begin.bracket.curly.go
 >			{ "Else" }
 #^^^ source.templ html-template.templ block.html-template.templ else.html-template.templ
 #   ^^ source.templ html-template.templ block.html-template.templ else.html-template.templ expression.html-template.templ start.string-expression.templ

--- a/tests/snap/basic_features.templ.snap
+++ b/tests/snap/basic_features.templ.snap
@@ -214,10 +214,10 @@
 >		} else {
 #^^ source.templ html-template.templ block.html-template.templ else-if.html-template.templ block.else-if.html-template.templ
 #  ^ source.templ html-template.templ block.html-template.templ else-if.html-template.templ block.else-if.html-template.templ punctuation.definition.end.bracket.curly.go
-#   ^ source.templ html-template.templ block.html-template.templ else.html-template.templ meta.embedded.block.go
-#    ^^^^ source.templ html-template.templ block.html-template.templ else.html-template.templ meta.embedded.block.go keyword.control.go
-#        ^ source.templ html-template.templ block.html-template.templ else.html-template.templ meta.embedded.block.go
-#         ^ source.templ html-template.templ block.html-template.templ else.html-template.templ meta.embedded.block.go punctuation.definition.begin.bracket.curly.go
+#   ^ source.templ html-template.templ block.html-template.templ else.html-template.templ
+#    ^^^^ source.templ html-template.templ block.html-template.templ else.html-template.templ keyword.control.go
+#        ^ source.templ html-template.templ block.html-template.templ else.html-template.templ
+#         ^ source.templ html-template.templ block.html-template.templ else.html-template.templ punctuation.definition.end.bracket.curly.go
 >			{ "Else" }
 #^^^ source.templ html-template.templ block.html-template.templ else.html-template.templ
 #   ^^ source.templ html-template.templ block.html-template.templ else.html-template.templ expression.html-template.templ start.string-expression.templ
@@ -227,7 +227,8 @@
 #           ^ source.templ html-template.templ block.html-template.templ else.html-template.templ expression.html-template.templ
 #            ^ source.templ html-template.templ block.html-template.templ else.html-template.templ expression.html-template.templ end.string-expression.templ
 >		}
-#^^^ source.templ html-template.templ block.html-template.templ else.html-template.templ meta.embedded.block.go
+#^^ source.templ html-template.templ block.html-template.templ else.html-template.templ
+#  ^ source.templ html-template.templ block.html-template.templ else.html-template.templ punctuation.definition.end.bracket.curly.go
 >	</div>
 #^ source.templ html-template.templ block.html-template.templ
 # ^^ source.templ html-template.templ block.html-template.templ meta.tag.block.any.html punctuation.definition.tag.begin.html

--- a/tests/snap/css_usage.templ.snap
+++ b/tests/snap/css_usage.templ.snap
@@ -23,9 +23,9 @@
 #                              ^ source.templ html-template.templ block.html-template.templ punctuation.definition.begin.bracket.curly.go
 >	<style>
 #^ source.templ html-template.templ block.html-template.templ
-# ^ source.templ html-template.templ block.html-template.templ meta.tag.inline.any.html punctuation.definition.tag.begin.html
-#  ^^^^^ source.templ html-template.templ block.html-template.templ meta.tag.inline.any.html entity.name.tag.inline.any.html
-#       ^ source.templ html-template.templ block.html-template.templ meta.tag.inline.any.html punctuation.definition.tag.end.html
+# ^ source.templ html-template.templ block.html-template.templ meta.tag.style.html punctuation.definition.tag.html
+#  ^^^^^ source.templ html-template.templ block.html-template.templ meta.tag.style.html entity.name.tag.html
+#       ^ source.templ html-template.templ block.html-template.templ meta.tag.style.html punctuation.definition.tag.html
 >	.test {
 #^ source.templ html-template.templ block.html-template.templ meta.tag.style.html
 # ^ source.templ html-template.templ block.html-template.templ meta.tag.style.html meta.selector.css entity.other.attribute-name.class.css punctuation.definition.entity.css


### PR DESCRIPTION
# Overview
Resolves: https://github.com/a-h/templ/issues/652. 

This PR removes the usage of wildcards in all of the lookbehind expressions mentioned in https://github.com/a-h/templ/issues/652. 

For `(?<=\s*})` lookbehind expressions, most were able to just remove the wildcard `\s` and work the same. The `else` expression did need some adjustments however to properly address the syntax highlighting of the match it's covering. 

For the script/style elements, these were previously added and later updated to fix inline tags. The way the lookbehind expression was previously used was allowing the `#element` match to find it first and lookbehind for script/style to start the new match. Instead, I moved `#script-element` and `#style-element` above `#element` in the top-level patterns so they will be matched first and made them more exact matching with proper closing brackets (`>`). I also copied down the HTML tokens into these captures.

Through testing a few different scenarios of each area I saw no regression, but would be worth a double check from different eyes. 