### PR TITLE
Feat: Add snippets

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "test:update": "vscode-tmgrammar-snap -g ./tests/go.tmLanguage.json -g ./tests/css.tmLanguage.json -g ./tests/JavaScript.tmLanguage.json --updateSnapshot 'tests/snap/**/*.templ'"
   },
   "categories": [
-    "Programming Languages"
+    "Programming Languages",
+    "Snippets"
   ],
   "contributes": {
     "languages": [
@@ -90,7 +91,13 @@
           "description": "Set to a value such as localhost:7474 to enable a HTTP endpoint that can be used for debugging (same as the templ -http argument)"
         }
       }
-    }
+    },
+    "snippets": [
+      {
+        "language": "templ",
+        "path": "./snippet/snippets.json"
+      }
+    ]
   },
   "devDependencies": {
     "@types/vscode": "1.88.0",

--- a/snippet/snippets.json
+++ b/snippet/snippets.json
@@ -1,0 +1,13 @@
+{
+    "Generate templ template": {
+        "prefix": "templ",
+        "body": [
+            "package ${package_name};",
+            "\n",
+            "templ ${template_name}(){",
+            "\t$0",
+            "}"
+        ],
+        "description": "Generate templ template"
+    }
+}


### PR DESCRIPTION
# Overview
When writing a template, it is common to repeat the same pattern:
1. Declare the package.
2. Write the definition of the first template.

With this PR, I would like to add a simple snippet to resolve this problem. 

## Screenshots
![Screenshot_20240425_022123](https://github.com/templ-go/templ-vscode/assets/26926690/51765de1-54f6-48c8-bfc5-70b1e7a3072d)




P.S: Thx so much for this amazing library and LSP, i am having fun writing templ files! Also would be also great to add a default template when creating a new file .templ using "New File" option (idk if possible...)


