### PR TITLE
feat: inherit all HTML language server features

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,8 +101,16 @@
       "explorer.fileNesting.patterns": {
         "*.templ": "${capture}_templ.go,${capture}_templ.txt"
       }
-    }
+    },
+    "htmlLanguageParticipants": [
+      {
+        "languageId": "templ"
+      }
+    ]    
   },
+  "extensionDependencies" : [
+    "vscode.html-language-features"
+  ],
   "devDependencies": {
     "@types/vscode": "1.88.0",
     "@vscode/test-electron": "2.3.9",


### PR DESCRIPTION
Should solve this issue https://github.com/a-h/templ/issues/498

We use this [feature](https://code.visualstudio.com/updates/v1_70#_htmllanguageparticipants-contribution-point) to allow the `templ` language to inherit HTML LSP features such as code completions, hovers, and outline.

I modified the package.json on my host and it's working

![image](https://github.com/user-attachments/assets/f74c001f-4cce-48dc-90bb-6d1c9eb472b3)
![image](https://github.com/user-attachments/assets/1d6f4051-f8f6-47f4-9018-a661971c66df)